### PR TITLE
rvstar: add an rtc example that displays time

### DIFF
--- a/rvstar/rtc/rtc_display_time/Makefile
+++ b/rvstar/rtc/rtc_display_time/Makefile
@@ -1,0 +1,9 @@
+TARGET = rtc_display_time
+
+NUCLEI_SDK_ROOT = ../../../..
+
+SRCDIRS = .
+
+INCDIRS = .
+
+include $(NUCLEI_SDK_ROOT)/Build/Makefile.base

--- a/rvstar/rtc/rtc_display_time/README.md
+++ b/rvstar/rtc/rtc_display_time/README.md
@@ -1,0 +1,64 @@
+# Introduction
+
+This is an RTC example for RVSTAR board that explains how to configure the RTC module. In this example, RTC peripheral is configured to display current time. Select LXTAL as RTC clock source. And the Serial Terminal should be connected to the RV-STAR board via COM0(UART4).
+
+# How to use
+
+## Build and run using Nuclei SDK
+
+Here are the steps build and run in Nuclei SDK using command line.
+
+~~~shell
+# clone nuclei-sdk repo and cd to it
+git clone https://github.com/Nuclei-Software/nuclei-sdk
+cd nuclei-sdk
+# Setup nuclei tools environment following https://doc.nucleisys.com/nuclei_sdk/quickstart.html#setup-tools-and-environment
+# Assume you are in Windows, and have create and setup the setup_config.bat file
+# source the nuclei tool environment
+setup.bat
+# clone nuclei-board-labs
+git clone https://github.com/Nuclei-Software/nuclei-board-labs
+cd nuclei-board-labs/
+# cd to this example
+cd rvstar/rtc/rtc_display_time
+# Build this example for nuclei rvstar board
+## clean this example first
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar clean
+## build this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar all
+## connect rvstar board using USB dongle, and make sure driver is setup correctly
+## see https://rvmcu.com/column-topic-id-464.html
+## upload this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar upload
+## debug this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar debug
+~~~
+
+After start-up, the program will check if the BKP data register is written to a key value. If the value is incorrect, the program will ask to set the time on the Serial Terminal. Then the current time will be displayed on the Serial Terminal. The RTC module is in the Backup Domain, which is not reset by the system reset.
+
+**You can also refer to this guide for more details:**
+
+* [GD32VF103V RV-STAR Kit Support for Nuclei SDK](https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103v_rvstar.html#design-board-gd32vf103v-rvstar)
+
+## Build and run using other tools
+
+If you are not familar with command line, you can also create projects using Nuclei Studio and PlatformIO IDE, put this example code in the IDE and then build, upload and debug on it.
+
+### Create a project
+
+You can create a project in Nuclei Studio IDE or PlatformIO IDE.
+
+### Copy the source code
+
+Copy the main.c file from this directory and replace the existing application code in the IDE project directory.
+
+### Build and Upload
+
+Connect RV-STAR board to your PC, build and upload the project and after start-up, the program will check if the BKP data register is written to a key value. If the value is incorrect, the program will ask to set the time on the Serial Terminal. Then the current time will be displayed on the Serial Terminal. The RTC module is in the Backup Domain, which is not reset by the system reset.
+
+## Reference
+
+* [RVMCU课堂 - 手把手教你玩转RVSTAR——Nuclei Studio+蜂鸟调试器篇](https://rvmcu.com/column-topic-id-455.html)
+* [RVMCU课堂 - 手把手教你玩转RVSTAR——PlatformIO篇](https://rvmcu.com/column-topic-id-452.html)
+* [Nuclei Studio User Guide 中文手册](https://nucleisys.com/upload/files/doc/nucleistudio/Nuclei_Studio_User_Guide.pdf)
+* [PlatformIO User Guide](https://docs.platformio.org/page/platforms/nuclei.html)

--- a/rvstar/rtc/rtc_display_time/main.c
+++ b/rvstar/rtc/rtc_display_time/main.c
@@ -1,0 +1,121 @@
+#include "nuclei_sdk_hal.h"
+#include "rtc.h"
+#include <stdio.h>
+
+#define BKP_DATA_REG_NUM        42
+
+extern __IO uint32_t timedisplay;
+
+/*!
+    \brief      main function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+int main(void)
+{
+    /* COM0 configure */
+    gd_com_init(GD32_COM0);
+
+    /* ECLIC configure */
+    ECLIC_Register_IRQ(RTC_IRQn, ECLIC_NON_VECTOR_INTERRUPT, ECLIC_LEVEL_TRIGGER, 1, 0, NULL);
+    __enable_irq();
+
+
+    printf("\r\n This is a RTC demo...... \r\n");
+
+    if (bkp_data_read(BKP_DATA_0) != 0xA5A5) {
+        /* backup data register value is not correct or not yet programmed
+        (when the first time the program is executed) */
+        printf("\r\nThis is a RTC demo!\r\n");
+        printf("\r\n\n RTC not yet configured....");
+
+        /* RTC configuration */
+        rtc_configuration();
+
+        printf("\r\n RTC configured....");
+
+        /* adjust time by values entred by the user on the hyperterminal */
+        time_adjust();
+
+        bkp_data_write(BKP_DATA_0, 0xA5A5);
+    } else {
+        /* check if the power on reset flag is set */
+        if (rcu_flag_get(RCU_FLAG_PORRST) != RESET) {
+            printf("\r\n\n Power On Reset occurred....");
+        } else if (rcu_flag_get(RCU_FLAG_SWRST) != RESET) {
+            /* check if the pin reset flag is set */
+            printf("\r\n\n External Reset occurred....");
+        }
+
+        /* allow access to BKP domain */
+        rcu_periph_clock_enable(RCU_PMU);
+        pmu_backup_write_enable();
+
+        printf("\r\n No need to configure RTC....");
+        /* wait for RTC registers synchronization */
+        rtc_register_sync_wait();
+
+        /* enable the RTC second */
+        rtc_interrupt_enable(RTC_INT_SECOND);
+
+        /* wait until last write operation on RTC registers has finished */
+        rtc_lwoff_wait();
+    }
+
+    /* clear reset flags */
+    rcu_all_reset_flag_clear();
+
+    /* display time in infinite loop */
+    time_show();
+
+    while (1) {
+    }
+}
+
+/*!
+    \brief      check if the backup data registers are clear or not
+    \param[in]  none
+    \param[out] none
+    \retval     the number of data register
+*/
+uint32_t is_backup_register_clear(void)
+{
+    uint32_t temp = 0;
+
+    for (temp = 0; temp < BKP_DATA_REG_NUM; temp++) {
+        if (temp < 10) {
+            /* check if the data of data register 0-9 is 0x0000 */
+            if (0x0000 != BKP_DATA_GET(BKP_DATA0_9(temp))) {
+                return temp + 1;
+            }
+        } else {
+            /* check if the data of data register 10-41 is 0x0000 */
+            if (0x0000 != BKP_DATA_GET(BKP_DATA10_41(temp))) {
+                return temp + 1;
+            }
+        }
+    }
+    return 0;
+}
+
+
+void RTC_IRQHandler(void)
+{
+    if (rtc_flag_get(RTC_FLAG_SECOND) != RESET) {
+        /* clear the RTC second interrupt flag*/
+        rtc_flag_clear(RTC_FLAG_SECOND);
+
+        /* enable time update */
+        timedisplay = 1;
+
+        /* wait until last write operation on RTC registers has finished */
+        rtc_lwoff_wait();
+        /* reset RTC counter when time is 23:59:59 */
+        if (rtc_counter_get() == 0x00015180) {
+            rtc_counter_set(0x0);
+            /* wait until last write operation on RTC registers has finished */
+            rtc_lwoff_wait();
+        }
+    }
+}

--- a/rvstar/rtc/rtc_display_time/rtc.c
+++ b/rvstar/rtc/rtc_display_time/rtc.c
@@ -1,0 +1,171 @@
+#include "rtc.h"
+
+/* enter the second interruption,set the second interrupt flag to 1 */
+__IO uint32_t timedisplay = 0;
+
+/*!
+    \brief      configure the RTC
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rtc_configuration(void)
+{
+    /* enable PMU and BKPI clocks */
+    rcu_periph_clock_enable(RCU_BKPI);
+    rcu_periph_clock_enable(RCU_PMU);
+    /* allow access to BKP domain */
+    pmu_backup_write_enable();
+
+    /* reset backup domain */
+    bkp_deinit();
+
+    /* enable LXTAL */
+    rcu_osci_on(RCU_LXTAL);
+    /* wait till LXTAL is ready */
+    rcu_osci_stab_wait(RCU_LXTAL);
+
+    /* select RCU_LXTAL as RTC clock source */
+    rcu_rtc_clock_config(RCU_RTCSRC_LXTAL);
+
+    /* enable RTC Clock */
+    rcu_periph_clock_enable(RCU_RTC);
+
+    /* wait for RTC registers synchronization */
+    rtc_register_sync_wait();
+
+    /* wait until last write operation on RTC registers has finished */
+    rtc_lwoff_wait();
+
+    /* enable the RTC second interrupt*/
+    rtc_interrupt_enable(RTC_INT_SECOND);
+
+    /* wait until last write operation on RTC registers has finished */
+    rtc_lwoff_wait();
+
+    /* set RTC prescaler: set RTC period to 1s */
+    rtc_prescaler_set(32767);
+
+    /* wait until last write operation on RTC registers has finished */
+    rtc_lwoff_wait();
+}
+
+/*!
+    \brief      return the time entered by user, using Hyperterminal
+    \param[in]  none
+    \param[out] none
+    \retval     current time of RTC counter value
+*/
+uint32_t time_regulate(void)
+{
+    uint32_t tmp_hh = 0xFF, tmp_mm = 0xFF, tmp_ss = 0xFF;
+
+    printf("\r\n==============Time Settings=====================================");
+    printf("\r\n  Please Set Hours");
+
+    while (tmp_hh == 0xFF) {
+        tmp_hh = usart_scanf(23);
+    }
+    printf(":  %d", tmp_hh);
+    printf("\r\n  Please Set Minutes");
+    while (tmp_mm == 0xFF) {
+        tmp_mm = usart_scanf(59);
+    }
+    printf(":  %d", tmp_mm);
+    printf("\r\n  Please Set Seconds");
+    while (tmp_ss == 0xFF) {
+        tmp_ss = usart_scanf(59);
+    }
+    printf(":  %d", tmp_ss);
+
+    /* return the value  store in RTC counter register */
+    return ((tmp_hh * 3600 + tmp_mm * 60 + tmp_ss));
+}
+
+/*!
+    \brief      adjust time
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void time_adjust(void)
+{
+    /* wait until last write operation on RTC registers has finished */
+    rtc_lwoff_wait();
+    /* change the current time */
+    rtc_counter_set(time_regulate());
+    /* wait until last write operation on RTC registers has finished */
+    rtc_lwoff_wait();
+}
+
+/*!
+    \brief      display the current time
+    \param[in]  timeVar: RTC counter value
+    \param[out] none
+    \retval     none
+*/
+void time_display(uint32_t timevar)
+{
+    uint32_t thh = 0, tmm = 0, tss = 0;
+
+    /* compute  hours */
+    thh = timevar / 3600;
+    /* compute minutes */
+    tmm = (timevar % 3600) / 60;
+    /* compute seconds */
+    tss = (timevar % 3600) % 60;
+
+    printf(" Time: %0.2d:%0.2d:%0.2d\r\n", thh, tmm, tss);
+}
+
+/*!
+    \brief      show the current time (HH:MM:SS) on the Hyperterminal
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void time_show(void)
+{
+    printf("\n\r");
+
+    /* infinite loop */
+    while (1) {
+        /* if 1s has paased */
+        if (timedisplay == 1) {
+            /* display current time */
+            time_display(rtc_counter_get());
+            timedisplay = 0;
+        }
+    }
+}
+
+/*!
+    \brief      get numeric values from the hyperterminal
+    \param[in]  value: input value from the hyperterminal
+    \param[out] none
+    \retval     input value in BCD mode
+*/
+uint8_t usart_scanf(uint32_t value)
+{
+    uint32_t index = 0;
+    uint32_t tmp[2] = {0, 0};
+
+    while (index < 2) {
+        /* loop until RBNE = 1 */
+        while (usart_flag_get(UART4, USART_FLAG_RBNE) == RESET);
+        tmp[index++] = (usart_data_receive(UART4));
+
+        if ((tmp[index - 1] < 0x30) || (tmp[index - 1] > 0x39)) {
+            printf("\n\rPlease enter valid number between 0 and 9\n");
+            index--;
+        }
+    }
+    /* calculate the Corresponding value */
+    index = (tmp[1] - 0x30) + ((tmp[0] - 0x30) * 10);
+    /* check */
+    if (index > value) {
+        printf("\n\rPlease enter valid number between 0 and %d\n", value);
+        return 0xFF;
+    }
+    return index;
+}

--- a/rvstar/rtc/rtc_display_time/rtc.h
+++ b/rvstar/rtc/rtc_display_time/rtc.h
@@ -1,0 +1,15 @@
+#ifndef __RTC_H
+#define __RTC_H
+
+#include "nuclei_sdk_hal.h"
+#include <stdio.h>
+
+void rtc_configuration(void);
+uint32_t time_regulate(void);
+void time_adjust(void);
+void time_display(uint32_t timevar);
+void time_show(void);
+uint8_t usart_scanf(uint32_t value);
+
+#endif /* __RTC_H */
+


### PR DESCRIPTION
Add an RTC example:
- In this example, RTC peripheral is configured to display current time.
- For detailed usage, please check README.md.