### PR TITLE
rvstar: add a fwdgt example

### DIFF
--- a/rvstar/wdgt/fwdgt_key_int/Makefile
+++ b/rvstar/wdgt/fwdgt_key_int/Makefile
@@ -1,0 +1,9 @@
+TARGET = fwdgt_key_int
+
+NUCLEI_SDK_ROOT = ../../../..
+
+SRCDIRS = .
+
+INCDIRS = .
+
+include $(NUCLEI_SDK_ROOT)/Build/Makefile.base

--- a/rvstar/wdgt/fwdgt_key_int/README.md
+++ b/rvstar/wdgt/fwdgt_key_int/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This is an FWDGT example for RVSTAR board that explains how to configure the FWDGT module. It shows how to reload the FWDGT counter at regulate period using the EXTI interrupt. The FWDGT timeout is set to 1000ms (the timeout may varies due to IRC40K frequency dispersion).
+This is an FWDGT example for RVSTAR board that explains how to configure the FWDGT module. It shows how to reload the FWDGT counter at regulate period in the main function and trigger the FWDGT reset by using an EXTI interrupt. The FWDGT timeout is set to 1000ms (the timeout may varies due to IRC40K frequency dispersion).
 
 # How to use
 

--- a/rvstar/wdgt/fwdgt_key_int/README.md
+++ b/rvstar/wdgt/fwdgt_key_int/README.md
@@ -1,0 +1,64 @@
+# Introduction
+
+This is an FWDGT example for RVSTAR board that explains how to configure the FWDGT module. It shows how to reload the FWDGT counter at regulate period using the EXTI interrupt. The FWDGT timeout is set to 1000ms (the timeout may varies due to IRC40K frequency dispersion).
+
+# How to use
+
+## Build and run using Nuclei SDK
+
+Here are the steps build and run in Nuclei SDK using command line.
+
+~~~shell
+# clone nuclei-sdk repo and cd to it
+git clone https://github.com/Nuclei-Software/nuclei-sdk
+cd nuclei-sdk
+# Setup nuclei tools environment following https://doc.nucleisys.com/nuclei_sdk/quickstart.html#setup-tools-and-environment
+# Assume you are in Windows, and have create and setup the setup_config.bat file
+# source the nuclei tool environment
+setup.bat
+# clone nuclei-board-labs
+git clone https://github.com/Nuclei-Software/nuclei-board-labs
+cd nuclei-board-labs/
+# cd to this example
+cd rvstar/wdgt/fwdgt_key_int
+# Build this example for nuclei rvstar board
+## clean this example first
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar clean
+## build this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar all
+## connect rvstar board using USB dongle, and make sure driver is setup correctly
+## see https://rvmcu.com/column-topic-id-464.html
+## upload this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar upload
+## debug this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar debug
+~~~
+
+After start-up, the red LED blinks once and then the green LED will blink constantly. When you press the KEY_WAKEUP, the green led stops blink and the blue led light up for approximately 1 second and the red LED will blink once and then the green LED will blink constantly again, which means the system is reset by the FWDGT.
+
+**You can also refer to this guide for more details:**
+
+* [GD32VF103V RV-STAR Kit Support for Nuclei SDK](https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103v_rvstar.html#design-board-gd32vf103v-rvstar)
+
+## Build and run using other tools
+
+If you are not familar with command line, you can also create projects using Nuclei Studio and PlatformIO IDE, put this example code in the IDE and then build, upload and debug on it.
+
+### Create a project
+
+You can create a project in Nuclei Studio IDE or PlatformIO IDE.
+
+### Copy the source code
+
+Copy the main.c file from this directory and replace the existing application code in the IDE project directory.
+
+### Build and Upload
+
+Connect RV-STAR board to your PC, build and upload the project and after start-up, the red LED blinks once and then the green LED will blink constantly. When you press the KEY_WAKEUP, the green led stops blink and the blue led light up for approximately 1 second and the red LED will blink once and then the green LED will blink constantly again, which means the system is reset by the FWDGT.
+
+## Reference
+
+* [RVMCU课堂 - 手把手教你玩转RVSTAR——Nuclei Studio+蜂鸟调试器篇](https://rvmcu.com/column-topic-id-455.html)
+* [RVMCU课堂 - 手把手教你玩转RVSTAR——PlatformIO篇](https://rvmcu.com/column-topic-id-452.html)
+* [Nuclei Studio User Guide 中文手册](https://nucleisys.com/upload/files/doc/nucleistudio/Nuclei_Studio_User_Guide.pdf)
+* [PlatformIO User Guide](https://docs.platformio.org/page/platforms/nuclei.html)

--- a/rvstar/wdgt/fwdgt_key_int/main.c
+++ b/rvstar/wdgt/fwdgt_key_int/main.c
@@ -1,0 +1,69 @@
+#include "nuclei_sdk_hal.h"
+
+uint32_t millis(void);
+uint32_t start = 0;
+uint32_t now = 0;
+
+int main()
+{
+    /* enable IRC40K */
+    rcu_osci_on(RCU_IRC40K);
+
+    /* wait till IRC40K is ready */
+    while (SUCCESS != rcu_osci_stab_wait(RCU_IRC40K)) ;
+
+    /* confiure FWDGT counter clock: 40KHz(IRC40K) / 64 = 0.625 KHz */
+    fwdgt_config(625, FWDGT_PSC_DIV64);
+    /* after 1 seconds to generate a reset */
+    fwdgt_enable();
+
+    gd_rvstar_led_init(LED1);
+    gd_rvstar_led_init(LED2);
+    gd_rvstar_led_init(LED3);
+
+    gd_rvstar_led_on(LED3);
+    delay_1ms(50);
+    gd_rvstar_led_off(LED3);
+
+    start = millis();
+
+    gd_rvstar_key_init(KEY_WAKEUP, KEY_MODE_EXTI);
+    __enable_irq();
+
+    while (1) {
+        now = millis();
+        if (now - start >= 900) {
+            fwdgt_counter_reload();
+            start = now;
+        }
+
+        /* toggle green led */
+        gd_rvstar_led_toggle(LED1);
+        delay_1ms(100);
+    }
+}
+
+void EXTI0_IRQHandler(void)
+{
+    if (RESET != exti_interrupt_flag_get(WAKEUP_KEY_EXTI_LINE)) {
+
+        if (RESET == gd_rvstar_key_state_get(KEY_WAKEUP)) {
+            gd_rvstar_led_off(LED1);
+            gd_rvstar_led_on(LED2);
+
+            while (1);
+        }
+    }
+    /* clear EXTI lines pending flag */
+    exti_interrupt_flag_clear(WAKEUP_KEY_EXTI_LINE);
+}
+
+/**
+ * \brief Returns the number of milliseconds since the board began running the current program.
+ *
+ * \return Number of milliseconds since the program started (uint32_t)
+ */
+uint32_t millis(void)
+{
+    return (uint32_t)(SysTimer_GetLoadValue() * (4000.F / SystemCoreClock));
+}


### PR DESCRIPTION
Add a fwdgt example:
- This example shows how to reload the FWDGT counter at regulate period in the main function and trigger the FWDGT reset by an EXTI interrupt.
- For detailed usage, please check README.md.