### PR TITLE
rvstar: add an adc example for rvstar

### DIFF
--- a/rvstar/adc/adc_regular_scan/Makefile
+++ b/rvstar/adc/adc_regular_scan/Makefile
@@ -1,0 +1,9 @@
+TARGET = adc_regular_scan
+
+NUCLEI_SDK_ROOT = ../../../..
+
+SRCDIRS = .
+
+INCDIRS = .
+
+include $(NUCLEI_SDK_ROOT)/Build/Makefile.base

--- a/rvstar/adc/adc_regular_scan/README.md
+++ b/rvstar/adc/adc_regular_scan/README.md
@@ -1,0 +1,64 @@
+# Introduction
+
+This is an ADC example for RVSTAR board which uses the PC0(ADC1_CH10) to read analog values and print them to the serial terminal.
+
+# How to use
+
+## Build and run using Nuclei SDK
+
+Here are the steps build and run in Nuclei SDK using command line.
+
+~~~shell
+# clone nuclei-sdk repo and cd to it
+git clone https://github.com/Nuclei-Software/nuclei-sdk
+cd nuclei-sdk
+# Setup nuclei tools environment following https://doc.nucleisys.com/nuclei_sdk/quickstart.html#setup-tools-and-environment
+# Assume you are in Windows, and have create and setup the setup_config.bat file
+# source the nuclei tool environment
+setup.bat
+# clone nuclei-board-labs
+git clone https://github.com/Nuclei-Software/nuclei-board-labs
+cd nuclei-board-labs/
+# cd to this example
+cd rvstar/adc/adc_regular_scan
+# Build this example for nuclei rvstar board
+## clean this example first
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar clean
+## build this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar all
+## connect rvstar board using USB dongle, and make sure driver is setup correctly
+## see https://rvmcu.com/column-topic-id-464.html
+## upload this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar upload
+## debug this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar debug
+~~~
+
+After start-up, the program will scan the analog values from the PC0 every 1000ms and print them to the serial terminal via the baudrate 115200.
+
+**You can also refer to this guide for more details:**
+
+* [GD32VF103V RV-STAR Kit Support for Nuclei SDK](https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103v_rvstar.html#design-board-gd32vf103v-rvstar)
+
+## Build and run using other tools
+
+If you are not familar with command line, you can also create projects using Nuclei Studio and PlatformIO IDE, put this example code in the IDE and then build, upload and debug on it.
+
+### Create a project
+
+You can create a project in Nuclei Studio IDE or PlatformIO IDE.
+
+### Copy the source code
+
+Copy the main.c file from this directory and replace the existing application code in the IDE project directory.
+
+### Build and Upload
+
+Connect RV-STAR board to your PC, build and upload the project and after start-up, the program will scan the analog values from the PC0 every 1000ms and print them to the serial terminal via the baudrate 115200.
+
+## Reference
+
+* [RVMCU课堂 - 手把手教你玩转RVSTAR——Nuclei Studio+蜂鸟调试器篇](https://rvmcu.com/column-topic-id-455.html)
+* [RVMCU课堂 - 手把手教你玩转RVSTAR——PlatformIO篇](https://rvmcu.com/column-topic-id-452.html)
+* [Nuclei Studio User Guide 中文手册](https://nucleisys.com/upload/files/doc/nucleistudio/Nuclei_Studio_User_Guide.pdf)
+* [PlatformIO User Guide](https://docs.platformio.org/page/platforms/nuclei.html)

--- a/rvstar/adc/adc_regular_scan/main.c
+++ b/rvstar/adc/adc_regular_scan/main.c
@@ -1,0 +1,62 @@
+#include "nuclei_sdk_hal.h"
+#include <stdio.h>
+
+void rcu_config(void);
+void gpio_config(void);
+void adc_config(void);
+
+uint16_t adc_value;
+
+int main(void)
+{
+    rcu_config();
+    gpio_config();
+    adc_config();
+    gd_com_init(GD32_COM0);
+
+    while (1) {
+        delay_1ms(1000);
+        adc_value = adc_regular_data_read(ADC1);
+
+        printf("\r\n ADC1 regular channel 10 data = %d \r\n", adc_value);
+        printf("\r\n ***********************************\r\n");
+    }
+}
+
+void rcu_config(void)
+{
+    rcu_periph_clock_enable(RCU_GPIOC);
+    rcu_periph_clock_enable(RCU_ADC1);
+    rcu_adc_clock_config(RCU_CKADC_CKAPB2_DIV8);
+}
+
+void gpio_config(void)
+{
+    gpio_init(GPIOC, GPIO_MODE_AIN, GPIO_OSPEED_50MHZ, GPIO_PIN_0);
+}
+
+void adc_config(void)
+{
+    /* reset ADC */
+    adc_deinit(ADC1);
+    /* ADC mode config */
+    adc_mode_config(ADC1, ADC_MODE_FREE);
+    /* ADC scan function enable */
+    adc_special_function_config(ADC1, ADC_SCAN_MODE, ENABLE);
+    /* ADC contineous function enable */
+    adc_special_function_config(ADC1, ADC_CONTINUOUS_MODE, ENABLE);
+    /* ADC data alignment config */
+    adc_data_alignment_config(ADC1, ADC_DATAALIGN_RIGHT);
+    /* ADC channel length config */
+    adc_channel_length_config(ADC1, ADC_REGULAR_CHANNEL, 1);
+
+    adc_external_trigger_source_config(ADC1, ADC_REGULAR_CHANNEL, ADC0_1_EXTTRIG_REGULAR_NONE);
+    adc_external_trigger_config(ADC1, ADC_REGULAR_CHANNEL, ENABLE);
+    delay_1ms(1);
+
+    adc_enable(ADC1);
+    adc_calibration_enable(ADC1);
+
+    adc_software_trigger_enable(ADC1, ADC_REGULAR_CHANNEL);
+    adc_regular_channel_config(ADC1, 0, ADC_CHANNEL_10, ADC_SAMPLETIME_55POINT5);
+}


### PR DESCRIPTION
Add an ADC example:
- RVSTAR  uses the PC0(ADC1_CH10) to read analog values and prints them to the serial terminal.
- For detailed usage, please check README.md