### PR TITLE
rvstar: add a DAC example

### DIFF
--- a/rvstar/dac/adc_dac_converter/Makefile
+++ b/rvstar/dac/adc_dac_converter/Makefile
@@ -1,0 +1,9 @@
+TARGET = adc_dac_converter
+
+NUCLEI_SDK_ROOT = ../../../..
+
+SRCDIRS = .
+
+INCDIRS = .
+
+include $(NUCLEI_SDK_ROOT)/Build/Makefile.base

--- a/rvstar/dac/adc_dac_converter/README.md
+++ b/rvstar/dac/adc_dac_converter/README.md
@@ -1,0 +1,67 @@
+# Introduction
+
+This is an DAC example for RVSTAR board which uses the PC0(ADC1_CH10) to read analog values and uses the PA5(DAC1) to output voltages of these values.
+
+# How to use
+
+## Connect the peripherals
+To observe the phenomenon of this program, you need connect a rotation potentiometer to the PC0 and a LED to the PA5.
+
+## Build and run using Nuclei SDK
+
+Here are the steps build and run in Nuclei SDK using command line.
+
+~~~shell
+# clone nuclei-sdk repo and cd to it
+git clone https://github.com/Nuclei-Software/nuclei-sdk
+cd nuclei-sdk
+# Setup nuclei tools environment following https://doc.nucleisys.com/nuclei_sdk/quickstart.html#setup-tools-and-environment
+# Assume you are in Windows, and have create and setup the setup_config.bat file
+# source the nuclei tool environment
+setup.bat
+# clone nuclei-board-labs
+git clone https://github.com/Nuclei-Software/nuclei-board-labs
+cd nuclei-board-labs/
+# cd to this example
+cd rvstar/dac/adc_dac_converter
+# Build this example for nuclei rvstar board
+## clean this example first
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar clean
+## build this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar all
+## connect rvstar board using USB dongle, and make sure driver is setup correctly
+## see https://rvmcu.com/column-topic-id-464.html
+## upload this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar upload
+## debug this example
+make SOC=gd32vf103 BOARD=gd32vf103v_rvstar debug
+~~~
+
+After start-up, the led will change its brightness when you rotate the potentiometer.
+
+**You can also refer to this guide for more details:**
+
+* [GD32VF103V RV-STAR Kit Support for Nuclei SDK](https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103v_rvstar.html#design-board-gd32vf103v-rvstar)
+
+## Build and run using other tools
+
+If you are not familar with command line, you can also create projects using Nuclei Studio and PlatformIO IDE, put this example code in the IDE and then build, upload and debug on it.
+
+### Create a project
+
+You can create a project in Nuclei Studio IDE or PlatformIO IDE.
+
+### Copy the source code
+
+Copy the main.c file from this directory and replace the existing application code in the IDE project directory.
+
+### Build and Upload
+
+Connect RV-STAR board to your PC, build and upload the project and after start-up, the led will change its brightness when you rotate the potentiometer.
+
+## Reference
+
+* [RVMCU课堂 - 手把手教你玩转RVSTAR——Nuclei Studio+蜂鸟调试器篇](https://rvmcu.com/column-topic-id-455.html)
+* [RVMCU课堂 - 手把手教你玩转RVSTAR——PlatformIO篇](https://rvmcu.com/column-topic-id-452.html)
+* [Nuclei Studio User Guide 中文手册](https://nucleisys.com/upload/files/doc/nucleistudio/Nuclei_Studio_User_Guide.pdf)
+* [PlatformIO User Guide](https://docs.platformio.org/page/platforms/nuclei.html)

--- a/rvstar/dac/adc_dac_converter/main.c
+++ b/rvstar/dac/adc_dac_converter/main.c
@@ -1,0 +1,77 @@
+#include "nuclei_sdk_hal.h"
+
+void rcu_config(void);
+void gpio_config(void);
+void adc_config(void);
+void dac_config(void);
+
+uint16_t input_value;
+
+int main()
+{
+    rcu_config();
+    gpio_config();
+    adc_config();
+    dac_config();
+
+    while (1) {
+        input_value = adc_regular_data_read(ADC1);
+        dac_data_set(DAC1, DAC_ALIGN_12B_R, input_value);
+        dac_software_trigger_enable(DAC1);
+
+        delay_1ms(50);
+    }
+
+}
+
+void rcu_config(void)
+{
+    /* enable the clock of peripherals */
+    rcu_periph_clock_enable(RCU_GPIOA);
+    rcu_periph_clock_enable(RCU_GPIOC);
+    rcu_periph_clock_enable(RCU_ADC1);
+    rcu_periph_clock_enable(RCU_DAC);
+}
+
+void gpio_config(void)
+{
+    /* config the GPIO as analog mode */
+    gpio_init(GPIOC, GPIO_MODE_AIN, GPIO_OSPEED_50MHZ, GPIO_PIN_0);
+    /* once enabled the DAC, the corresponding GPIO pin is connected to the DAC converter automatically */
+    gpio_init(GPIOA, GPIO_MODE_AIN, GPIO_OSPEED_50MHZ, GPIO_PIN_5);
+}
+
+void adc_config(void)
+{
+    /* reset ADC */
+    adc_deinit(ADC1);
+    /* ADC mode config */
+    adc_mode_config(ADC1, ADC_MODE_FREE);
+    /* ADC scan function enable */
+    adc_special_function_config(ADC1, ADC_SCAN_MODE, ENABLE);
+    /* ADC contineous function enable */
+    adc_special_function_config(ADC1, ADC_CONTINUOUS_MODE, ENABLE);
+    /* ADC data alignment config */
+    adc_data_alignment_config(ADC1, ADC_DATAALIGN_RIGHT);
+    /* ADC channel length config */
+    adc_channel_length_config(ADC1, ADC_REGULAR_CHANNEL, 1);
+    adc_external_trigger_source_config(ADC1, ADC_REGULAR_CHANNEL, ADC0_1_EXTTRIG_REGULAR_NONE);
+    adc_external_trigger_config(ADC1, ADC_REGULAR_CHANNEL, ENABLE);
+    delay_1ms(1);
+
+    adc_enable(ADC1);
+    adc_calibration_enable(ADC1);
+
+    adc_software_trigger_enable(ADC1, ADC_REGULAR_CHANNEL);
+    adc_regular_channel_config(ADC1, 0, ADC_CHANNEL_10, ADC_SAMPLETIME_55POINT5);
+}
+
+void dac_config(void)
+{
+    dac_deinit();
+    /* configure the DAC1 */
+    dac_trigger_source_config(DAC1, DAC_TRIGGER_SOFTWARE);
+    dac_trigger_enable(DAC1);
+    /* enable DAC1 */
+    dac_enable(DAC1);
+}


### PR DESCRIPTION
Add a DAC example:
- RVSTAR uses ADC1 to read the analog values and sends them to DAC1.
- For detailed usage, please check README.md