### PR TITLE
npk: add npk feature support

### DIFF
--- a/e203_hbirdv2/common/demo_iasm/npk.yml
+++ b/e203_hbirdv2/common/demo_iasm/npk.yml
@@ -1,18 +1,18 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-e203_hbirdv2_common_demo_iasm
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei e203_hbirdv2 common demo_iasm lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/e203_hbirdv2/common/demo_iasm
 
 ## Package Dependency
 dependencies:
-  - name: bsp-nsdk_gd32vf103v_rvstar
+  - name: ssp-hsdk_hbirdv2
     owner: nuclei
     version:
 

--- a/e203_hbirdv2/common/demo_nice/npk.yml
+++ b/e203_hbirdv2/common/demo_nice/npk.yml
@@ -1,25 +1,25 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-e203_hbirdv2_common_demo_nice
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei e203_hbirdv2 common demo_nice lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/e203_hbirdv2/common/demo_nice
 
 ## Package Dependency
 dependencies:
-  - name: bsp-nsdk_gd32vf103v_rvstar
+  - name: ssp-hsdk_hbirdv2
     owner: nuclei
     version:
 
 ## Package Configurations
 configuration:
   app_commonflags:
-    value:
+    value: -O0
     type: text
     description: Application Compile Flags
 

--- a/e203_hbirdv2/common/gpio_toggle/npk.yml
+++ b/e203_hbirdv2/common/gpio_toggle/npk.yml
@@ -1,18 +1,18 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-e203_hbirdv2_common_gpio_toggle
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei e203_hbirdv2 common gpio_toggle lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/e203_hbirdv2/common/gpio_toggle
 
 ## Package Dependency
 dependencies:
-  - name: bsp-nsdk_gd32vf103v_rvstar
+  - name: ssp-hsdk_hbirdv2
     owner: nuclei
     version:
 

--- a/e203_hbirdv2/common/i2c_eeprom/npk.yml
+++ b/e203_hbirdv2/common/i2c_eeprom/npk.yml
@@ -1,18 +1,18 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-e203_hbirdv2_common_i2c_eeprom
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei e203_hbirdv2 common i2c_eeprom lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/e203_hbirdv2/common/i2c_eeprom
 
 ## Package Dependency
 dependencies:
-  - name: bsp-nsdk_gd32vf103v_rvstar
+  - name: ssp-hsdk_hbirdv2
     owner: nuclei
     version:
 

--- a/e203_hbirdv2/ddr200t/pwm_led/npk.yml
+++ b/e203_hbirdv2/ddr200t/pwm_led/npk.yml
@@ -1,18 +1,18 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-e203_hbirdv2_ddr200t_pwm_led
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei e203_hbirdv2 ddr200t pwm_led lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/e203_hbirdv2/ddr200t/pwm_led
 
 ## Package Dependency
 dependencies:
-  - name: bsp-nsdk_gd32vf103v_rvstar
+  - name: bsp-hsdk_ddr200t
     owner: nuclei
     version:
 

--- a/e203_hbirdv2/ddr200t/spi_lcd/npk.yml
+++ b/e203_hbirdv2/ddr200t/spi_lcd/npk.yml
@@ -1,18 +1,18 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-e203_hbirdv2_ddr200t_spi_lcd
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei e203_hbirdv2 ddr200t spi_lcd lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/e203_hbirdv2/ddr200t/spi_lcd
 
 ## Package Dependency
 dependencies:
-  - name: bsp-nsdk_gd32vf103v_rvstar
+  - name: bsp-hsdk_ddr200t
     owner: nuclei
     version:
 

--- a/e203_hbirdv2/mcu200t/pwm_led/npk.yml
+++ b/e203_hbirdv2/mcu200t/pwm_led/npk.yml
@@ -1,18 +1,18 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-e203_hbirdv2_mcu200t_pwm_led
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei e203_hbirdv2 mcu200t pwm_led lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/e203_hbirdv2/mcu200t/pwm_led
 
 ## Package Dependency
 dependencies:
-  - name: bsp-nsdk_gd32vf103v_rvstar
+  - name: bsp-hsdk_mcu200t
     owner: nuclei
     version:
 

--- a/gennpk.sh
+++ b/gennpk.sh
@@ -1,0 +1,55 @@
+#!/bin/env bash
+
+FORCE=false
+
+HOMEPAGE="https://github.com/Nuclei-Software/nuclei-board-labs/tree/master"
+
+if [ "x$1" == "x-f" ] ; then
+    FORCE=true
+    echo "Will overwrite existing npk.yml if found!"
+fi
+
+for board in e203_hbirdv2 rvstar ;
+do
+    appmks=($(find $board -type f -name "Makefile"))
+    for appmk in ${appmks[@]};
+    do
+        appdir=$(dirname $appmk)
+        # https://stackoverflow.com/questions/5928156/replace-one-character-with-another-in-bash
+        appname=${appdir//\//_}
+        appdesc="${appdir//\// }"
+        appflags=""
+        apphomepage="$HOMEPAGE/$appdir"
+        match=$(grep "COMMON_FLAGS" $appmk)
+        if [[ $? == 0 ]] ; then
+            appflags="$(echo $match | cut -d "=" -f2)"
+            # strip whitespace in appflags
+            # https://stackoverflow.com/a/12973694
+            appflags=" $(echo $appflags | xargs)"
+            echo "Found $match in $appmk"
+        fi
+        if [ "$board" == "e203_hbirdv2" ] ; then
+            if [[ "$appdir" == *"/common/"*  ]] ; then
+                appdep="ssp-hsdk_hbirdv2"
+            elif [[ "$appdir" == *"/ddr200t/"* ]] ; then
+                appdep="bsp-hsdk_ddr200t"
+            elif [[ "$appdir" == *"/mcu200t/"* ]] ; then
+                appdep="bsp-hsdk_mcu200t"
+            fi
+        elif [ "$board" == "rvstar" ] ; then
+            appdep="bsp-nsdk_gd32vf103v_rvstar"
+        else
+            continue
+        fi
+        appnpkyml=$appdir/npk.yml
+        if [ ! -f $appnpkyml ] ||  $FORCE ; then
+            cp -f npk.yml.tpl $appnpkyml
+            sed -i 's|`appname`|'"$appname"'|g'  $appnpkyml
+            sed -i 's|`appdesc`|'"$appdesc"'|g'  $appnpkyml
+            sed -i 's|`appdep`|'"$appdep"'|g'  $appnpkyml
+            sed -i 's|`appflags`|'"$appflags"'|g'  $appnpkyml
+            sed -i 's|`apphomepage`|'"$apphomepage"'|g'  $appnpkyml
+            echo "Generate $appnpkyml"
+        fi
+    done
+done

--- a/npk.yml
+++ b/npk.yml
@@ -1,0 +1,15 @@
+## Package Base Information
+name: bdp-nuclei_board_labs
+owner: nuclei
+version: 1.0.0
+description: Nuclei board labs for e203_hbirdv2 and rvstar
+type: bdp
+keywords:
+  - application
+  - risc-v
+license: Apache-2.0
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs
+contributors:
+  - Can Hu, hucan0216@163.com
+  - Yang Xu, zeonphantom@163.com
+  - Huaqi Fang, 578567190@qq.com

--- a/npk.yml.tpl
+++ b/npk.yml.tpl
@@ -1,0 +1,50 @@
+## Package Base Information
+name: app-`appname`
+owner: nuclei
+version: 1.0.0
+description: Nuclei `appdesc` lab
+type: app
+keywords:
+  - nuclei board labs
+category: Board Labs
+license: Apache-2.0
+homepage: `apphomepage`
+
+## Package Dependency
+dependencies:
+  - name: `appdep`
+    owner: nuclei
+    version:
+
+## Package Configurations
+configuration:
+  app_commonflags:
+    value:`appflags`
+    type: text
+    description: Application Compile Flags
+
+## Source Code Management
+codemanage:
+  copyfiles:
+    - path: ["*.c", "*.h", "*.S", "*.s", "*.C"]
+  incdirs:
+    - path: ["./"]
+  libdirs:
+  ldlibs:
+    - libs: ["m"]
+
+## Build Configuration
+buildconfig:
+  - type: gcc
+    common_flags: # flags need to be combined together across all packages
+      - flags: ${app_commonflags}
+    ldflags:
+    cflags:
+    asmflags:
+    cxxflags:
+    prebuild_steps: # could be override by app/bsp type
+      command:
+      description:
+    postbuild_steps: # could be override by app/bsp type
+      command:
+      description:

--- a/rvstar/adc/adc_regular_scan/npk.yml
+++ b/rvstar/adc/adc_regular_scan/npk.yml
@@ -1,0 +1,55 @@
+## Package Base Information
+name: app-rvstar_adc_regular_scan
+owner: nuclei
+version:
+description: ADC Regular Scan Demo for RVSTAR Board
+type: app
+keywords:
+  - baremetal
+  - ADC
+  - RVSTAR
+category: baremetal application
+license: Apache-2.0
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs
+
+## Package Dependency
+dependencies:
+  - name: bsp-nsdk_gd32vf103v_rvstar
+    version:
+
+## Package Configurations
+configuration:
+  app_commonflags:
+    value:
+    type: text
+    description: Application Compile Flags
+
+## Set Configuration for other packages
+setconfig:
+
+
+## Source Code Management
+codemanage:
+  copyfiles:
+    - path: ["*.c", "*.h"]
+  incdirs:
+    - path: ["./"]
+  libdirs:
+  ldlibs:
+    - libs:
+
+## Build Configuration
+buildconfig:
+  - type: gcc
+    common_flags: # flags need to be combined together across all packages
+      - flags: ${app_commonflags}
+    ldflags:
+    cflags:
+    asmflags:
+    cxxflags:
+    prebuild_steps: # could be override by app/bsp type
+      command:
+      description:
+    postbuild_steps: # could be override by app/bsp type
+      command:
+      description:

--- a/rvstar/crc/crc_single_data/npk.yml
+++ b/rvstar/crc/crc_single_data/npk.yml
@@ -1,0 +1,55 @@
+## Package Base Information
+name: app-rvstar_crc_single_data
+owner: nuclei
+version:
+description: CRC Calc Demo for RVSTAR Board
+type: app
+keywords:
+  - baremetal
+  - CRC
+  - RVSTAR
+category: baremetal application
+license: Apache-2.0
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs
+
+## Package Dependency
+dependencies:
+  - name: bsp-nsdk_gd32vf103v_rvstar
+    version:
+
+## Package Configurations
+configuration:
+  app_commonflags:
+    value:
+    type: text
+    description: Application Compile Flags
+
+## Set Configuration for other packages
+setconfig:
+
+
+## Source Code Management
+codemanage:
+  copyfiles:
+    - path: ["*.c", "*.h"]
+  incdirs:
+    - path: ["./"]
+  libdirs:
+  ldlibs:
+    - libs:
+
+## Build Configuration
+buildconfig:
+  - type: gcc
+    common_flags: # flags need to be combined together across all packages
+      - flags: ${app_commonflags}
+    ldflags:
+    cflags:
+    asmflags:
+    cxxflags:
+    prebuild_steps: # could be override by app/bsp type
+      command:
+      description:
+    postbuild_steps: # could be override by app/bsp type
+      command:
+      description:

--- a/rvstar/crc/crc_single_data/npk.yml
+++ b/rvstar/crc/crc_single_data/npk.yml
@@ -1,20 +1,19 @@
 ## Package Base Information
-name: app-rvstar_crc_single_data
+name: app-rvstar_crc_crc_single_data
 owner: nuclei
-version:
-description: CRC Calc Demo for RVSTAR Board
+version: 1.0.0
+description: Nuclei rvstar crc crc_single_data lab
 type: app
 keywords:
-  - baremetal
-  - CRC
-  - RVSTAR
-category: baremetal application
+  - nuclei board labs
+category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/crc/crc_single_data
 
 ## Package Dependency
 dependencies:
   - name: bsp-nsdk_gd32vf103v_rvstar
+    owner: nuclei
     version:
 
 ## Package Configurations
@@ -24,19 +23,15 @@ configuration:
     type: text
     description: Application Compile Flags
 
-## Set Configuration for other packages
-setconfig:
-
-
 ## Source Code Management
 codemanage:
   copyfiles:
-    - path: ["*.c", "*.h"]
+    - path: ["*.c", "*.h", "*.S", "*.s", "*.C"]
   incdirs:
     - path: ["./"]
   libdirs:
   ldlibs:
-    - libs:
+    - libs: ["m"]
 
 ## Build Configuration
 buildconfig:

--- a/rvstar/dac/adc_dac_converter/npk.yml
+++ b/rvstar/dac/adc_dac_converter/npk.yml
@@ -1,0 +1,56 @@
+## Package Base Information
+name: app-rvstar_adc_dac_converter
+owner: nuclei
+version:
+description: ADC and DAC Converter Demo for RVSTAR Board
+type: app
+keywords:
+  - baremetal
+  - DAC
+  - ADC
+  - RVSTAR
+category: baremetal application
+license: Apache-2.0
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs
+
+## Package Dependency
+dependencies:
+  - name: bsp-nsdk_gd32vf103v_rvstar
+    version:
+
+## Package Configurations
+configuration:
+  app_commonflags:
+    value:
+    type: text
+    description: Application Compile Flags
+
+## Set Configuration for other packages
+setconfig:
+
+
+## Source Code Management
+codemanage:
+  copyfiles:
+    - path: ["*.c", "*.h"]
+  incdirs:
+    - path: ["./"]
+  libdirs:
+  ldlibs:
+    - libs:
+
+## Build Configuration
+buildconfig:
+  - type: gcc
+    common_flags: # flags need to be combined together across all packages
+      - flags: ${app_commonflags}
+    ldflags:
+    cflags:
+    asmflags:
+    cxxflags:
+    prebuild_steps: # could be override by app/bsp type
+      command:
+      description:
+    postbuild_steps: # could be override by app/bsp type
+      command:
+      description:

--- a/rvstar/dac/adc_dac_converter/npk.yml
+++ b/rvstar/dac/adc_dac_converter/npk.yml
@@ -1,21 +1,19 @@
 ## Package Base Information
-name: app-rvstar_adc_dac_converter
+name: app-rvstar_dac_adc_dac_converter
 owner: nuclei
-version:
-description: ADC and DAC Converter Demo for RVSTAR Board
+version: 1.0.0
+description: Nuclei rvstar dac adc_dac_converter lab
 type: app
 keywords:
-  - baremetal
-  - DAC
-  - ADC
-  - RVSTAR
-category: baremetal application
+  - nuclei board labs
+category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/dac/adc_dac_converter
 
 ## Package Dependency
 dependencies:
   - name: bsp-nsdk_gd32vf103v_rvstar
+    owner: nuclei
     version:
 
 ## Package Configurations
@@ -25,19 +23,15 @@ configuration:
     type: text
     description: Application Compile Flags
 
-## Set Configuration for other packages
-setconfig:
-
-
 ## Source Code Management
 codemanage:
   copyfiles:
-    - path: ["*.c", "*.h"]
+    - path: ["*.c", "*.h", "*.S", "*.s", "*.C"]
   incdirs:
     - path: ["./"]
   libdirs:
   ldlibs:
-    - libs:
+    - libs: ["m"]
 
 ## Build Configuration
 buildconfig:

--- a/rvstar/demo_iasm/npk.yml
+++ b/rvstar/demo_iasm/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_demo_iasm
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar demo_iasm lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/demo_iasm
 
 ## Package Dependency
 dependencies:

--- a/rvstar/dma/dma_ram_uart/npk.yml
+++ b/rvstar/dma/dma_ram_uart/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_dma_dma_ram_uart
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar dma dma_ram_uart lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/dma/dma_ram_uart
 
 ## Package Dependency
 dependencies:

--- a/rvstar/exti_key_interrupt/npk.yml
+++ b/rvstar/exti_key_interrupt/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_exti_key_interrupt
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar exti_key_interrupt lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/exti_key_interrupt
 
 ## Package Dependency
 dependencies:

--- a/rvstar/gpio/gpio_input_key/npk.yml
+++ b/rvstar/gpio/gpio_input_key/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_gpio_gpio_input_key
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar gpio gpio_input_key lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/gpio/gpio_input_key
 
 ## Package Dependency
 dependencies:

--- a/rvstar/gpio/gpio_output_led/npk.yml
+++ b/rvstar/gpio/gpio_output_led/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_gpio_gpio_output_led
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar gpio gpio_output_led lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/gpio/gpio_output_led
 
 ## Package Dependency
 dependencies:

--- a/rvstar/i2c/i2c_oled_screen/npk.yml
+++ b/rvstar/i2c/i2c_oled_screen/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_i2c_i2c_oled_screen
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar i2c i2c_oled_screen lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/i2c/i2c_oled_screen
 
 ## Package Dependency
 dependencies:

--- a/rvstar/nesting_of_interrupts/npk.yml
+++ b/rvstar/nesting_of_interrupts/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_nesting_of_interrupts
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar nesting_of_interrupts lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/nesting_of_interrupts
 
 ## Package Dependency
 dependencies:

--- a/rvstar/pmu/deepsleep_wakeup_exti/npk.yml
+++ b/rvstar/pmu/deepsleep_wakeup_exti/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_pmu_deepsleep_wakeup_exti
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar pmu deepsleep_wakeup_exti lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/pmu/deepsleep_wakeup_exti
 
 ## Package Dependency
 dependencies:

--- a/rvstar/rtc/rtc_display_time/npk.yml
+++ b/rvstar/rtc/rtc_display_time/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_rtc_rtc_display_time
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar rtc rtc_display_time lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/rtc/rtc_display_time
 
 ## Package Dependency
 dependencies:

--- a/rvstar/running_led/npk.yml
+++ b/rvstar/running_led/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_running_led
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar running_led lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/running_led
 
 ## Package Dependency
 dependencies:

--- a/rvstar/spi/spi_master_polling/npk.yml
+++ b/rvstar/spi/spi_master_polling/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_spi_spi_master_polling
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar spi spi_master_polling lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/spi/spi_master_polling
 
 ## Package Dependency
 dependencies:

--- a/rvstar/timer/timer_encoder_counter/npk.yml
+++ b/rvstar/timer/timer_encoder_counter/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_timer_timer_encoder_counter
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar timer timer_encoder_counter lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/timer/timer_encoder_counter
 
 ## Package Dependency
 dependencies:

--- a/rvstar/timer/timer_pwmout_buzzer/npk.yml
+++ b/rvstar/timer/timer_pwmout_buzzer/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_timer_timer_pwmout_buzzer
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar timer timer_pwmout_buzzer lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/timer/timer_pwmout_buzzer
 
 ## Package Dependency
 dependencies:

--- a/rvstar/timer/timer_pwmout_light/npk.yml
+++ b/rvstar/timer/timer_pwmout_light/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_timer_timer_pwmout_light
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar timer timer_pwmout_light lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/timer/timer_pwmout_light
 
 ## Package Dependency
 dependencies:

--- a/rvstar/uart/uart_control_led/npk.yml
+++ b/rvstar/uart/uart_control_led/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_uart_uart_control_led
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar uart uart_control_led lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/uart/uart_control_led
 
 ## Package Dependency
 dependencies:

--- a/rvstar/uart/uart_return_char/npk.yml
+++ b/rvstar/uart/uart_return_char/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_uart_uart_return_char
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar uart uart_return_char lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/uart/uart_return_char
 
 ## Package Dependency
 dependencies:

--- a/rvstar/uart/uart_return_string/npk.yml
+++ b/rvstar/uart/uart_return_string/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_uart_uart_return_string
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar uart uart_return_string lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/uart/uart_return_string
 
 ## Package Dependency
 dependencies:

--- a/rvstar/vectored_interrupt/npk.yml
+++ b/rvstar/vectored_interrupt/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_vectored_interrupt
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar vectored_interrupt lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/vectored_interrupt
 
 ## Package Dependency
 dependencies:

--- a/rvstar/wdgt/fwdgt_key_int/npk.yml
+++ b/rvstar/wdgt/fwdgt_key_int/npk.yml
@@ -1,14 +1,14 @@
 ## Package Base Information
-name: app-rvstar_adc_adc_regular_scan
+name: app-rvstar_wdgt_fwdgt_key_int
 owner: nuclei
 version: 1.0.0
-description: Nuclei rvstar adc adc_regular_scan lab
+description: Nuclei rvstar wdgt fwdgt_key_int lab
 type: app
 keywords:
   - nuclei board labs
 category: Board Labs
 license: Apache-2.0
-homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/adc/adc_regular_scan
+homepage: https://github.com/Nuclei-Software/nuclei-board-labs/tree/master/rvstar/wdgt/fwdgt_key_int
 
 ## Package Dependency
 dependencies:


### PR DESCRIPTION
Required Nuclei Studio 2022.04 version.

Not working with 2022.01 version.